### PR TITLE
Reduce API calls

### DIFF
--- a/ghcl/github_stats.py
+++ b/ghcl/github_stats.py
@@ -1,17 +1,15 @@
-from multiprocessing import Pool
 from typing import List
 
-import requests
-
 from ghcl.models.pull_request import PullRequest
+from ghcl.models.pull_request_lite import LitePullRequest
+from ghcl.requests_wrapper import http_get
 
 
 class GithubStats:
     def __init__(self, access_token):
         self._request_headers = {'Authorization': f'token {access_token}'}
 
-    def list_of_prs(self, user_name: str, state=None,
-                    request_parallelization_count=5) -> List[PullRequest]:
+    def list_of_prs(self, user_name: str) -> List[LitePullRequest]:
         url = 'https://api.github.com/search/issues'
         params = dict(
             q=f'is:pr author:{user_name} archived:false',
@@ -20,41 +18,38 @@ class GithubStats:
             per_page='100'
         )
 
-
         items = self._request(url=url, params=params)['items']
-        prs = Pool(request_parallelization_count).map(
-            self._to_pull_request, items)
-
-        if state is None:
-            return prs
-        else:
-            def stateNotEqual(pr: PullRequest) -> bool:
-                return pr._state != state
-
-            return filter(stateNotEqual, prs)
+        return list(map(self._to_lite_pull_request, items))
 
     def user_id_from_name(self, user_name: str) -> str:
         url = f"https://api.github.com/users/{user_name}"
-        return self._request(url).json()['id']
+        return self._request(url)['id']
 
-    def _to_pull_request(self, issues_data: dict) -> PullRequest:
-        pr_data = self._request(issues_data['pull_request']['url']).json()
-        all_data = {'issues_data': {**issues_data}, 'pr_data': {**pr_data}}
-        return PullRequest(**all_data)
+    def fetch_pr_data(self, lite_pr: LitePullRequest) -> PullRequest:
+        pr_data = self._request(lite_pr.pull_request_url)
+        kwargs = {
+            'lite_pr': lite_pr,
+            'pr_data': pr_data
+        }
+        return PullRequest(**kwargs)
+
+    def _to_lite_pull_request(self,
+                              issues_data: dict) -> LitePullRequest:
+        all_data = {'issues_data': {**issues_data}}
+        return LitePullRequest(**all_data)
 
     def _paginated_request(self, url: str, params: dict = None) -> dict:
         response = self._request(url, params)
         aggregate_response = response.json()['items']
         while 'next' in response.links.keys():
-            response = requests.get(response.links['next']['url'], params)
-            if 'items' in response.json().keys():
-                aggregate_response += (response.json()['items'])
+            response = self._request(
+                url=response.links['next']['url'],
+                params=params
+            )
+            if 'items' in response.keys():
+                aggregate_response += (response['items'])
         res = {'items': aggregate_response}
         return res
 
     def _request(self, url: str, params: dict = None) -> dict:
-        return requests.get(
-            url=url,
-            params=params,
-            headers=self._request_headers
-        )
+        return http_get(url, params, request_headers=self._request_headers)

--- a/ghcl/models/pull_request.py
+++ b/ghcl/models/pull_request.py
@@ -1,15 +1,15 @@
-from typing import List
 from datetime import datetime
 
 
 class PullRequest:
     def __init__(self, *args, **kwargs):
-        self._url = kwargs['issues_data']['pull_request']['html_url']
-        self._state = kwargs['issues_data']['state']
-        self._labels = PullRequest._label_names(
-            kwargs['issues_data']['labels'])
-        self._created_at = PullRequest._parse_date(
-            kwargs['issues_data']['created_at'])
+        lite_pr = kwargs['lite_pr']
+
+        self._html_url = lite_pr._html_url
+        self._state = lite_pr._state
+        self._labels = lite_pr._labels
+        self._created_at = lite_pr._created_at
+
         self._owner = kwargs['pr_data']['base']['repo']['owner']['login']
         self._pr_raised_by = kwargs['pr_data']['head']['user']['login']
         self._merged = kwargs['pr_data']['merged']
@@ -56,19 +56,11 @@ class PullRequest:
             date_summary = f" | Created at: {self._created_at}"
         else:
             date_summary = ""
-        return f"URL: {self._url} | Score: {self.score()}{date_summary}"
-
-    @staticmethod
-    def _parse_date(date_str: str) -> datetime:
-        return datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ')
-
-    @staticmethod
-    def _label_names(labels: List[dict]) -> List[str]:
-        return [label['name'] for label in labels]
+        return f"URL: {self._html_url} | Score: {self.score()}{date_summary}"
 
     def to_dict(self):
         return {
-            "url": self._url,
+            "url": self._html_url,
             "score": self.score(),
             "created_at": self._created_at
         }

--- a/ghcl/models/pull_request_lite.py
+++ b/ghcl/models/pull_request_lite.py
@@ -1,0 +1,25 @@
+from typing import List
+from datetime import datetime
+
+
+class LitePullRequest:
+    def __init__(self, *args, **kwargs):
+        self._html_url = kwargs['issues_data']['pull_request']['html_url']
+        self._state = kwargs['issues_data']['state']
+        self._labels = LitePullRequest._label_names(
+            kwargs['issues_data']['labels'])
+        self._created_at = LitePullRequest._parse_date(
+            kwargs['issues_data']['created_at'])
+        self.pull_request_url = kwargs['issues_data']['pull_request']['url']
+
+    def created_between(self, start_date: datetime,
+                        end_date: datetime) -> bool:
+        return start_date <= self._created_at <= end_date
+
+    @staticmethod
+    def _parse_date(date_str: str) -> datetime:
+        return datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%SZ')
+
+    @staticmethod
+    def _label_names(labels: List[dict]) -> List[str]:
+        return [label['name'] for label in labels]

--- a/ghcl/requests_wrapper.py
+++ b/ghcl/requests_wrapper.py
@@ -1,0 +1,16 @@
+import requests
+
+
+def http_get(url: str,
+             params: dict = None,
+             request_headers: dict = None) -> dict:
+    response = requests.get(
+        url=url,
+        params=params,
+        headers=request_headers
+    )
+
+    if isinstance(response, dict):
+        return response
+    else:
+        return response.json()

--- a/tests/models/pr_test_data.py
+++ b/tests/models/pr_test_data.py
@@ -2,6 +2,7 @@ import copy
 import json
 
 from ghcl.models.pull_request import PullRequest
+from ghcl.models.pull_request_lite import LitePullRequest
 
 
 class PRData:
@@ -12,9 +13,11 @@ class PRData:
         else:
             self._data = data
 
-    def with_pr_url(self, url: str = 'some-url'):
+    def with_pr_url(self, html_url: str = 'some-html-url',
+                    url: str = 'some-url'):
         data = copy.deepcopy(self._data)
-        data['issues_data']['pull_request']['html_url'] = url
+        data['issues_data']['pull_request']['html_url'] = html_url
+        data['issues_data']['pull_request']['url'] = url
         return PRData(data)
 
     def with_label(self, label_to_add: str = None):
@@ -62,4 +65,8 @@ class PRData:
             .with_state()
 
     def as_pull_request(self):
-        return PullRequest(**self._data)
+        data = {'lite_pr': LitePullRequest(**self._data), **self._data}
+        return PullRequest(**data)
+
+    def as_lite_pull_request(self):
+        return LitePullRequest(**self._data)

--- a/tests/models/pull_request_lite_test.py
+++ b/tests/models/pull_request_lite_test.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+from tests.models.pr_test_data import PRData
+
+_input = PRData().with_defaults()
+
+
+class TestDefaults:
+    @staticmethod
+    def test_should_create_pull_request():
+        pr = _input.as_lite_pull_request()
+
+        assert pr._html_url == 'some-html-url'
+        assert pr._state == 'some_state'
+        assert pr._labels == ['label-1', 'label-2']
+        assert pr._created_at == datetime(2014, 4, 24, 16, 34, 47)
+        assert pr.pull_request_url == 'some-url'
+
+
+class TestCreatedBetween:
+    @staticmethod
+    def test_in_between():
+        pr = _input.with_created_at(
+            '2019-12-25T16:35:49Z').as_lite_pull_request()
+
+        assert pr.created_between(
+            start_date=datetime(2018, 1, 1),
+            end_date=datetime(2020, 1, 1)
+        )
+
+    @staticmethod
+    def test_not_in_between():
+        pr = _input.with_created_at(
+            '2019-12-25T16:35:49Z').as_lite_pull_request()
+
+        assert pr.created_between(
+            start_date=datetime(2020, 1, 1),
+            end_date=datetime(2021, 1, 1)
+        ) is False
+
+    @staticmethod
+    def test_created_at_start():
+        pr = _input.with_created_at(
+            '2019-12-25T16:35:49Z').as_lite_pull_request()
+
+        assert pr.created_between(
+            start_date=datetime(2019, 12, 25, 16, 35, 49),
+            end_date=datetime(2021, 1, 1)
+        )
+
+    @staticmethod
+    def test_created_at_end():
+        pr = _input.with_created_at(
+            '2019-12-25T16:35:49Z').as_lite_pull_request()
+
+        assert pr.created_between(
+            start_date=datetime(2017, 1, 1),
+            end_date=datetime(2019, 12, 25, 16, 35, 49)
+        )

--- a/tests/models/pull_request_test.py
+++ b/tests/models/pull_request_test.py
@@ -10,7 +10,7 @@ class TestDefaults:
     def test_should_create_pull_request():
         pr = _input.as_pull_request()
 
-        assert pr._url == 'some-url'
+        assert pr._html_url == 'some-html-url'
         assert pr._state == 'some_state'
         assert pr._labels == ['label-1', 'label-2']
         assert pr._created_at == datetime(2014, 4, 24, 16, 34, 47)
@@ -22,18 +22,19 @@ class TestDefaults:
     def test_summary():
         pr = _input.as_pull_request()
 
-        assert pr.summary() == 'URL: some-url | Score: 0'
+        assert pr.summary() == 'URL: some-html-url | Score: 0'
 
     @staticmethod
     def test_summary_without_date():
         pr = _input.as_pull_request()
 
-        assert pr.summary(False) == 'URL: some-url | Score: 0'
+        assert pr.summary(False) == 'URL: some-html-url | Score: 0'
 
     @staticmethod
     def test_summary_with_date():
         pr = _input.as_pull_request()
-        expected = 'URL: some-url | Score: 0 | Created at: 2014-04-24 16:34:47'
+        expected = \
+            'URL: some-html-url | Score: 0 | Created at: 2014-04-24 16:34:47'
 
         assert pr.summary(True) == expected
 

--- a/tests/models/user_stats_test.py
+++ b/tests/models/user_stats_test.py
@@ -11,8 +11,8 @@ def test_leaderboard():
 
 def test_prs():
     expected = """User: Apple - Score: 13 (PRs: 2)
-  URL: some-url | Score: 3
-  URL: some-url | Score: 10
+  URL: some-html-url | Score: 3
+  URL: some-html-url | Score: 10
 """
 
     assert user_stats().prs_data() == expected
@@ -20,8 +20,8 @@ def test_prs():
 
 def test_all():
     expected = """User: Apple - Score: 13 (PRs: 2)
-  URL: some-url | Score: 3 | Created at: 2010-12-24 16:34:47
-  URL: some-url | Score: 10 | Created at: 2020-11-25 18:35:50
+  URL: some-html-url | Score: 3 | Created at: 2010-12-24 16:34:47
+  URL: some-html-url | Score: 10 | Created at: 2020-11-25 18:35:50
 """
 
     assert user_stats().all_data() == expected
@@ -32,12 +32,12 @@ def test_to_dict():
         "user_name": "Apple",
         "prs": [
             {
-                "url": "some-url",
+                "url": "some-html-url",
                 "score": 3,
                 "created_at": datetime(2010, 12, 24, 16, 34, 47)
             },
             {
-                "url": "some-url",
+                "url": "some-html-url",
                 "score": 10,
                 "created_at": datetime(2020, 11, 25, 18, 35, 50)
             }


### PR DESCRIPTION
only fetching PR details for PRs which are within the target date

Remove multiprocessing to remove the open file handle count issue when a large number of usernames are provided

## Checklist
- [x] Have you followed the [guidelines for contributing](https://github.com/javatarz/github-contribution-leaderboard/blob/master/contributing.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/javatarz/github-contribution-leaderboard/pulls) for the same feature you're adding?
- [x] Have you run tests (`pipenv run pytest`) before sending this PR?
- [x] Have you run linting (`./lint.sh`) before sending this PR?
